### PR TITLE
Systemd service file

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,11 +69,9 @@ Or you can run it manually but not recommended since you won't lock down the con
 
 #### Warning
 
-We recommend running sig_helper inside a locked down environment like an LXC container or a systemd service where only the strict necessary is allowed.
-
-No example outside of Docker have been written for this but feel free to send your contribution.
-
 This service runs untrusted code directly from Google.
+
+We recommend running sig_helper inside a locked down environment like an LXC container or a systemd service where only the strict necessary is allowed. An examplary systemd service file is provided in `inv_sig_helper.service` which creates a socket in `/home/invidious/tmp/inv_sig_helper.sock`.
 
 #### Instructions
 

--- a/inv_sig_helper.service
+++ b/inv_sig_helper.service
@@ -1,0 +1,80 @@
+[Unit]
+Description=inv_sig_helper (decrypt YouTube signatures and manage player information)
+After=syslog.target
+After=network.target
+
+[Service]
+RestartSec=2s
+Type=simple
+
+User=invidious
+Group=invidious
+
+# allow only the strict necessary since this service runs untrusted code directly from Google
+CapabilityBoundingSet=~CAP_SETUID CAP_SETGID CAP_SETPCAP
+CapabilityBoundingSet=~CAP_SYS_ADMIN
+CapabilityBoundingSet=~CAP_SYS_PTRACE
+CapabilityBoundingSet=~CAP_CHOWN CAP_FSETID CAP_SETFCAP
+CapabilityBoundingSet=~CAP_DAC_OVERRIDE CAP_DAC_READ_SEARCH CAP_FOWNER CAP_IPC_OWNER
+CapabilityBoundingSet=~CAP_NET_ADMIN
+CapabilityBoundingSet=~CAP_SYS_MODULE
+CapabilityBoundingSet=~CAP_SYS_RAWIO
+CapabilityBoundingSet=~CAP_SYS_TIME
+CapabilityBoundingSet=~CAP_AUDIT_CONTROL CAP_AUDIT_READ CAP_AUDIT_WRITE
+CapabilityBoundingSet=~CAP_KILL
+CapabilityBoundingSet=~CAP_NET_BIND_SERVICE CAP_NET_BROADCAST CAP_NET_RAW
+CapabilityBoundingSet=~CAP_SYSLOG
+CapabilityBoundingSet=~CAP_SYS_NICE CAP_SYS_RESOURCE
+CapabilityBoundingSet=~CAP_MAC_ADMIN CAP_MAC_OVERRIDE
+CapabilityBoundingSet=~CAP_SYS_BOOT
+CapabilityBoundingSet=~CAP_LINUX_IMMUTABLE
+CapabilityBoundingSet=~CAP_IPC_LOCK
+CapabilityBoundingSet=~CAP_SYS_CHROOT
+CapabilityBoundingSet=~CAP_BLOCK_SUSPEND
+CapabilityBoundingSet=~CAP_LEASE
+CapabilityBoundingSet=~CAP_SYS_PACCT
+CapabilityBoundingSet=~CAP_SYS_TTY_CONFIG
+CapabilityBoundingSet=~CAP_WAKE_ALARM
+LockPersonality=true
+MemoryDenyWriteExecute=true
+NoNewPrivileges=true
+PrivateDevices=true
+PrivateTmp=true
+PrivateUsers=true
+ProcSubset=pid
+ProtectControlGroups=true
+ProtectHome=tmpfs
+ProtectHostname=true
+ProtectKernelLogs=true
+ProtectKernelModules=true
+ProtectKernelTunables=true
+ProtectProc=invisible
+ProtectSystem=strict
+RemoveIPC=true
+RestrictAddressFamilies=AF_INET AF_INET6 AF_UNIX
+RestrictNamespaces=true
+RestrictSUIDSGID=true
+RestrictRealtime=true
+SystemCallArchitectures=native
+SystemCallFilter=~@clock
+SystemCallFilter=~@debug
+SystemCallFilter=~@module
+SystemCallFilter=~@mount
+SystemCallFilter=~@raw-io
+SystemCallFilter=~@reboot
+SystemCallFilter=~@swap
+SystemCallFilter=~@privileged
+SystemCallFilter=~@resources
+SystemCallFilter=~@cpu-emulation
+SystemCallFilter=~@obsolete
+
+BindReadOnlyPaths=/home/invidious/inv_sig_helper
+BindPaths=/home/invidious/tmp
+
+WorkingDirectory=/home/invidious/inv_sig_helper
+ExecStart=/home/invidious/inv_sig_helper/target/release/inv_sig_helper_rust /home/invidious/tmp/inv_sig_helper.sock
+
+Restart=always
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
I have no prior experience with systemd sandboxing. I used the tool `systemd-analyze security` to restrict the permissions of the inv_sig_helper service as much as possible (see below). With this service file, the service is executed as user `invidious` and a socket is created in `/home/invidious/tmp/inv_sig_helper.sock`. The service cannot create the socket in `/tmp` because of the setting `PrivateTmp=true`. 

Note that, when using the `--tcp` option, the set of restriction would need to be modified slightly.

```
$ systemd-analyze security inv_sig_helper.service
  NAME                                                        DESCRIPTION                                                               EXPOSURE
✗ PrivateNetwork=                                             Service has access to the host's network                                       0.5
✓ User=/DynamicUser=                                          Service runs under a static non-root user identity                                
✓ CapabilityBoundingSet=~CAP_SET(UID|GID|PCAP)                Service cannot change UID/GID identities/capabilities                             
✓ CapabilityBoundingSet=~CAP_SYS_ADMIN                        Service has no administrator privileges                                           
✓ CapabilityBoundingSet=~CAP_SYS_PTRACE                       Service has no ptrace() debugging abilities                                       
✗ RestrictAddressFamilies=~AF_(INET|INET6)                    Service may allocate Internet sockets                                          0.3
✓ RestrictNamespaces=~CLONE_NEWUSER                           Service cannot create user namespaces                                             
✓ RestrictAddressFamilies=~…                                  Service cannot allocate exotic sockets                                            
✓ CapabilityBoundingSet=~CAP_(CHOWN|FSETID|SETFCAP)           Service cannot change file ownership/access mode/capabilities                     
✓ CapabilityBoundingSet=~CAP_(DAC_*|FOWNER|IPC_OWNER)         Service cannot override UNIX file/IPC permission checks                           
✓ CapabilityBoundingSet=~CAP_NET_ADMIN                        Service has no network configuration privileges                                   
✓ CapabilityBoundingSet=~CAP_SYS_MODULE                       Service cannot load kernel modules                                                
✓ CapabilityBoundingSet=~CAP_SYS_RAWIO                        Service has no raw I/O access                                                     
✓ CapabilityBoundingSet=~CAP_SYS_TIME                         Service processes cannot change the system clock                                  
✓ DeviceAllow=                                                Service has a minimal device ACL                                                  
✗ IPAddressDeny=                                              Service does not define an IP address allow list                               0.2
✓ KeyringMode=                                                Service doesn't share key material with other services                            
✓ NoNewPrivileges=                                            Service processes cannot acquire new privileges                                   
✓ NotifyAccess=                                               Service child processes cannot alter service state                                
✓ PrivateDevices=                                             Service has no access to hardware devices                                         
✓ PrivateMounts=                                              Service cannot install system mounts                                              
✓ PrivateTmp=                                                 Service has no access to other software's temporary files                         
✓ PrivateUsers=                                               Service does not have access to other users                                       
✗ ProtectClock=                                               Service may write to the hardware clock or system clock                        0.2
✓ ProtectControlGroups=                                       Service cannot modify the control group file system                               
✗ ProtectHome=                                                Service has access to fake empty home directories                              0.1
✓ ProtectKernelLogs=                                          Service cannot read from or write to the kernel log ring buffer                   
✓ ProtectKernelModules=                                       Service cannot load or read kernel modules                                        
✓ ProtectKernelTunables=                                      Service cannot alter kernel tunables (/proc/sys, …)                               
✓ ProtectProc=                                                Service has restricted access to process tree (/proc hidepid=)                    
✓ ProtectSystem=                                              Service has strict read-only access to the OS file hierarchy                      
✓ RestrictAddressFamilies=~AF_PACKET                          Service cannot allocate packet sockets                                            
✓ RestrictSUIDSGID=                                           SUID/SGID file creation by service is restricted                                  
✓ SystemCallArchitectures=                                    Service may execute system calls only with native ABI                             
✓ SystemCallFilter=~@clock                                    System call deny list defined for service, and @clock is included                 
✓ SystemCallFilter=~@debug                                    System call deny list defined for service, and @debug is included                 
✓ SystemCallFilter=~@module                                   System call deny list defined for service, and @module is included                
✓ SystemCallFilter=~@mount                                    System call deny list defined for service, and @mount is included                 
✓ SystemCallFilter=~@raw-io                                   System call deny list defined for service, and @raw-io is included                
✓ SystemCallFilter=~@reboot                                   System call deny list defined for service, and @reboot is included                
✓ SystemCallFilter=~@swap                                     System call deny list defined for service, and @swap is included                  
✓ SystemCallFilter=~@privileged                               System call deny list defined for service, and @privileged is included            
✓ SystemCallFilter=~@resources                                System call deny list defined for service, and @resources is included             
✓ AmbientCapabilities=                                        Service process does not receive ambient capabilities                             
✓ CapabilityBoundingSet=~CAP_AUDIT_*                          Service has no audit subsystem access                                             
✓ CapabilityBoundingSet=~CAP_KILL                             Service cannot send UNIX signals to arbitrary processes                           
✓ CapabilityBoundingSet=~CAP_MKNOD                            Service cannot create device nodes             
✓ CapabilityBoundingSet=~CAP_NET_(BIND_SERVICE|BROADCAST|RAW) Service has no elevated networking privileges                                     
✓ CapabilityBoundingSet=~CAP_SYSLOG                           Service has no access to kernel logging                                           
✓ CapabilityBoundingSet=~CAP_SYS_(NICE|RESOURCE)              Service has no privileges to change resource use parameters                       
✓ RestrictNamespaces=~CLONE_NEWCGROUP                         Service cannot create cgroup namespaces                                           
✓ RestrictNamespaces=~CLONE_NEWIPC                            Service cannot create IPC namespaces                                              
✓ RestrictNamespaces=~CLONE_NEWNET                            Service cannot create network namespaces                                          
✓ RestrictNamespaces=~CLONE_NEWNS                             Service cannot create file system namespaces                                      
✓ RestrictNamespaces=~CLONE_NEWPID                            Service cannot create process namespaces                                          
✓ RestrictRealtime=                                           Service realtime scheduling access is restricted                                  
✓ SystemCallFilter=~@cpu-emulation                            System call deny list defined for service, and @cpu-emulation is included         
✓ SystemCallFilter=~@obsolete                                 System call deny list defined for service, and @obsolete is included              
✓ RestrictAddressFamilies=~AF_NETLINK                         Service cannot allocate netlink sockets                                           
✗ RootDirectory=/RootImage=                                   Service runs within the host's root directory                                  0.1
✓ SupplementaryGroups=                                        Service has no supplementary groups                                               
✓ CapabilityBoundingSet=~CAP_MAC_*                            Service cannot adjust SMACK MAC                                                   
✓ CapabilityBoundingSet=~CAP_SYS_BOOT                         Service cannot issue reboot()                                                     
✓ Delegate=                                                   Service does not maintain its own delegated control group subtree                 
✓ LockPersonality=                                            Service cannot change ABI personality                                             
✓ MemoryDenyWriteExecute=                                     Service cannot create writable executable memory mappings                         
✓ RemoveIPC=                                                  Service user cannot leave SysV IPC objects around                                 
✓ RestrictNamespaces=~CLONE_NEWUTS                            Service cannot create hostname namespaces                                         
✗ UMask=                                                      Files created by service are world-readable by default                         0.1
✓ CapabilityBoundingSet=~CAP_LINUX_IMMUTABLE                  Service cannot mark files immutable                                               
✓ CapabilityBoundingSet=~CAP_IPC_LOCK                         Service cannot lock memory into RAM                                               
✓ CapabilityBoundingSet=~CAP_SYS_CHROOT                       Service cannot issue chroot()                                                     
✓ ProtectHostname=                                            Service cannot change system host/domainname                                      
✓ CapabilityBoundingSet=~CAP_BLOCK_SUSPEND                    Service cannot establish wake locks                                               
✓ CapabilityBoundingSet=~CAP_LEASE                            Service cannot create file leases                                                 
✓ CapabilityBoundingSet=~CAP_SYS_PACCT                        Service cannot use acct()                                                         
✓ CapabilityBoundingSet=~CAP_SYS_TTY_CONFIG                   Service cannot issue vhangup()                                                    
✓ CapabilityBoundingSet=~CAP_WAKE_ALARM                       Service cannot program timers that wake up the system                             
✗ RestrictAddressFamilies=~AF_UNIX                            Service may allocate local sockets                                             0.1
✓ ProcSubset=                                                 Service has no access to non-process /proc files (/proc subset=)                  

→ Overall exposure level for inv_sig_helper.service: 1.2 OK 🙂
```