### PR TITLE
Implement logging

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,55 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.6.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
+dependencies = [
+ "anstyle",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "async-lock"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -99,6 +148,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "colorchoice"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -136,6 +191,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "env_filter"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f2c92ceda6ceec50f43169f9ee8424fe2db276791afde7b2cd8bc084cb376ab"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13fa619b91fb2381732789fc5de83b45675e882f66623b7d8cb4f643017018d"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "humantime",
+ "log",
 ]
 
 [[package]]
@@ -363,6 +441,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d897f394bad6a705d5f4104762e116a75639e470d80901eed05a860a95cb1904"
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
 name = "hyper"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -442,8 +526,10 @@ dependencies = [
 name = "inv_sig_helper_rust"
 version = "0.1.0"
 dependencies = [
+ "env_logger",
  "futures",
  "lazy-regex",
+ "log",
  "regex",
  "reqwest",
  "rquickjs",
@@ -457,6 +543,12 @@ name = "ipnet"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f518f335dce6725a761382244631d86cf0ccb2863413590b31338feb467f9c3"
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itoa"
@@ -526,9 +618,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.21"
+version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90ed8c1e510134f979dbc4f070f87d4313098b704861a105fe34231c70a3901c"
+checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
 name = "memchr"
@@ -1214,6 +1306,12 @@ dependencies = [
  "idna",
  "percent-encoding",
 ]
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,8 @@ lazy-regex = "3.1.0"
 tub = "0.3.7"
 tokio-util = { version = "0.7.10", features=["futures-io", "futures-util", "codec"]}
 futures = "0.3.30"
+log = "0.4.22"
+env_logger = "0.11.5"
 
 # Compilation optimizations for release builds
 # Increases compile time but typically produces a faster and smaller binary. Suitable for final releases but not for debug builds.

--- a/README.md
+++ b/README.md
@@ -93,6 +93,18 @@ The service can run in Unix socket mode (default) or TCP mode:
 
    If no IP:PORT is given, it defaults to `127.0.0.1:12999`.
 
+#### Troubleshooting
+
+The log level can be configured using the `RUST_LOG` environment variable. Valid values are:
+
+- error
+- warn
+- info
+- debug
+- trace
+
+The `info` log level is the default setting. Changing this to `debug` will provide detailed logs on each request for additional troubleshooting.
+
 
 ## Protocol Format
 

--- a/src/jobs.rs
+++ b/src/jobs.rs
@@ -1,6 +1,7 @@
 use futures::SinkExt;
 use rquickjs::{async_with, AsyncContext, AsyncRuntime};
 use std::{num::NonZeroUsize, sync::Arc, thread::available_parallelism, time::SystemTime};
+use log::{debug, error};
 use tokio::{runtime::Handle, sync::Mutex, task::block_in_place};
 use tub::Pool;
 
@@ -164,11 +165,11 @@ pub async fn process_decrypt_n_signature<W>(
                 Ok(x) => x,
                 Err(n) => {
                     if n.is_exception() {
-                        println!("JavaScript interpreter error (nsig code): {:?}", ctx.catch().as_exception());
+                        error!("JavaScript interpreter error (nsig code): {:?}", ctx.catch().as_exception());
                     } else {
-                        println!("JavaScript interpreter error (nsig code): {}", n);
+                        error!("JavaScript interpreter error (nsig code): {}", n);
                     }
-                    println!("Code: {}", player_info.nsig_function_code.clone());
+                    debug!("Code: {}", player_info.nsig_function_code.clone());
                     writer = cloned_writer.lock().await;
                     let _ = writer.send(OpcodeResponse {
                         opcode: JobOpcode::DecryptNSignature,
@@ -192,11 +193,11 @@ pub async fn process_decrypt_n_signature<W>(
             Ok(x) => x,
             Err(n) => {
                 if n.is_exception() {
-                    println!("JavaScript interpreter error (nsig code): {:?}", ctx.catch().as_exception());
+                    error!("JavaScript interpreter error (nsig code): {:?}", ctx.catch().as_exception());
                 } else {
-                    println!("JavaScript interpreter error (nsig code): {}", n);
+                    error!("JavaScript interpreter error (nsig code): {}", n);
                 }
-                println!("Code: {}", call_string.clone());
+                debug!("Code: {}", call_string.clone());
                 writer = cloned_writer.lock().await;
                 let _ = writer.send(OpcodeResponse {
                     opcode: JobOpcode::DecryptNSignature,
@@ -243,11 +244,11 @@ pub async fn process_decrypt_signature<W>(
                 Ok(x) => x,
                 Err(n) => {
                     if n.is_exception() {
-                        println!("JavaScript interpreter error (sig code): {:?}", ctx.catch().as_exception());
+                        error!("JavaScript interpreter error (sig code): {:?}", ctx.catch().as_exception());
                     } else {
-                        println!("JavaScript interpreter error (sig code): {}", n);
+                        error!("JavaScript interpreter error (sig code): {}", n);
                     }
-                    println!("Code: {}", player_info.sig_function_code.clone());
+                    debug!("Code: {}", player_info.sig_function_code.clone());
                     writer = cloned_writer.lock().await;
                     let _ = writer.send(OpcodeResponse {
                         opcode: JobOpcode::DecryptSignature,
@@ -274,11 +275,11 @@ pub async fn process_decrypt_signature<W>(
             Ok(x) => x,
             Err(n) => {
                 if n.is_exception() {
-                    println!("JavaScript interpreter error (sig code): {:?}", ctx.catch().as_exception());
+                    error!("JavaScript interpreter error (sig code): {:?}", ctx.catch().as_exception());
                 } else {
-                    println!("JavaScript interpreter error (sig code): {}", n);
+                    error!("JavaScript interpreter error (sig code): {}", n);
                 }
-                println!("Code: {}", call_string.clone());
+                debug!("Code: {}", call_string.clone());
                 writer = cloned_writer.lock().await;
                 let _ = writer.send(OpcodeResponse {
                     opcode: JobOpcode::DecryptSignature,

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1,5 +1,5 @@
 use std::io::ErrorKind;
-
+use log::debug;
 use tokio_util::{
     bytes::{Buf, BufMut},
     codec::{Decoder, Encoder},
@@ -52,7 +52,7 @@ impl Decoder for OpcodeDecoder {
         &mut self,
         src: &mut tokio_util::bytes::BytesMut,
     ) -> Result<Option<Self::Item>, Self::Error> {
-        //println!("Decoder length: {}", src.len());
+        debug!("Decoder length: {}", src.len());
         if 5 > src.len() {
             return Ok(None);
         }


### PR DESCRIPTION
This PR changes all the println invocations to appropriate calls from the log crate. 

I've also restored the commented-out print statements used historically for debugging and replaced them with debug! macro invocations so an end-user can re-enable them for troubleshooting purposes.

I've used the env_logger crate as an implementation for the log crate since it's simple and implements the RUST_LOG environment variable handling the way it is documented in the docker-compose file. 

I've tested this PR on my own private invidious instance. 