### PR TITLE
refactor: simplify code, use format!, more idiomatic code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -395,6 +395,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "hermit-abi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -533,6 +539,8 @@ dependencies = [
  "regex",
  "reqwest",
  "rquickjs",
+ "strum",
+ "strum_macros",
  "tokio",
  "tokio-util",
  "tub",
@@ -970,6 +978,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "beb461507cee2c2ff151784c52762cf4d9ff6a61f3e80968600ed24fa837fa54"
 
 [[package]]
+name = "rustversion"
+version = "1.0.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
+
+[[package]]
 name = "ryu"
 version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1088,6 +1102,25 @@ checksum = "05ffd9c0a93b7543e062e759284fcf5f5e3b098501104bfbdde4d404db792871"
 dependencies = [
  "libc",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,8 @@ tokio-util = { version = "0.7.10", features=["futures-io", "futures-util", "code
 futures = "0.3.30"
 log = "0.4.22"
 env_logger = "0.11.5"
+strum = "0.26.3"
+strum_macros = "0.26.4"
 
 # Compilation optimizations for release builds
 # Increases compile time but typically produces a faster and smaller binary. Suitable for final releases but not for debug builds.

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -25,4 +25,4 @@ pub static REGEX_SIGNATURE_FUNCTION: &Lazy<Regex> =
 pub static REGEX_HELPER_OBJ_NAME: &Lazy<Regex> = regex!(";([A-Za-z0-9_\\$]{2,})\\...\\(");
 
 pub static NSIG_FUNCTION_NAME: &str = "decrypt_nsig";
-pub static SIG_FUNCTION_NAME: &str = "decrypt_sig";
+pub static _SIG_FUNCTION_NAME: &str = "decrypt_sig";

--- a/src/opcode.rs
+++ b/src/opcode.rs
@@ -1,5 +1,5 @@
-use std::io::ErrorKind;
 use log::debug;
+use std::io::ErrorKind;
 use tokio_util::{
     bytes::{Buf, BufMut},
     codec::{Decoder, Encoder},


### PR DESCRIPTION
Attempt to simplify the existing code and to use more idiomatic code, without changing the semantics.

- Use format! macro instead of appending to a mutable String::new()
- Add `strum` to derive `Display` and `FromRepr` for `JobOpcode` automatically
- Implement `Default` for `PlayerInfo`
- Satisfy clippy lints
- Fix some typos in comments and logs
- Remove duplicate state cloning code in `process_socket`