### PR TITLE
Enable quickjs bindgen so bindings are built for unsupported targets

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 regex = "1.10.4"
-rquickjs = {version = "0.6.0", features=["futures", "parallel"]}
+rquickjs = {version = "0.6.0", features=["bindgen", "futures", "parallel"]}
 tokio = { version = "1.37.0", features = ["full", "net", "macros", "rt-multi-thread", "io-std", "io-util", "mio"] }
 reqwest = "0.12.4"
 lazy-regex = "3.1.0"


### PR DESCRIPTION
This PR enables bindgen for quickjs, so bindings are built for unsupported targets.
Tested with FreeBSD 14.1, rust 1.81

Related to https://github.com/iv-org/inv_sig_helper/issues/30 and https://github.com/iv-org/inv_sig_helper/issues/33