### PR TITLE
Fix REGEX_HELPER_OBJ_NAME - round 2

### DIFF
--- a/src/consts.rs
+++ b/src/consts.rs
@@ -34,7 +34,7 @@ pub static REGEX_SIGNATURE_FUNCTION: Lazy<Regex> = Lazy::new(|| {
         r#")"#
     )).unwrap()
 });
-pub static REGEX_HELPER_OBJ_NAME: &Lazy<Regex> = regex!(r"([A-Za-z0-9_\$]{1,})=function\(");
+pub static REGEX_HELPER_OBJ_NAME: &Lazy<Regex> = regex!(r"function\(([a-zA-Z_$][a-zA-Z0-9_$]*)\)|([a-zA-Z_$][a-zA-Z0-9_$]*)\.[A-Za-z_$]");
 
 pub static NSIG_FUNCTION_NAME: &str = "decrypt_nsig";
 pub static SIG_FUNCTION_NAME: &str = "decrypt_sig";

--- a/src/player.rs
+++ b/src/player.rs
@@ -182,10 +182,9 @@ pub async fn fetch_update(state: Arc<GlobalState>) -> Result<(), FetchUpdateStat
     // Get the helper object
     let helper_object_name = REGEX_HELPER_OBJ_NAME
         .captures(sig_function_body)
-        .unwrap()
-        .get(1)
-        .unwrap()
-        .as_str();
+        .and_then(|cap| cap.get(1).or_else(|| cap.get(2)))
+        .map(|m| m.as_str())
+        .unwrap_or_default();
 
     let mut helper_object_body_regex_str = String::new();
     helper_object_body_regex_str += "(var ";


### PR DESCRIPTION
Fixes https://github.com/iv-org/inv_sig_helper/issues/44

Regex did not account for object reference (`p.T`):
```
[2024-12-17T19:52:37Z DEBUG inv_sig_helper_rust::player] sig function name: j
[2024-12-17T19:52:37Z DEBUG inv_sig_helper_rust::player] got sig fn code: j=function(p){for(;p.T.C;)try{var C=p.C(p.T);if(C)return p.T.D=!1,{value:C.value,done:!1}
thread 'main' panicked at src/player.rs:186:10:
called Option::unwrap() on a None value
```

The new regex has two parts:

1. matches function parameters like `function(p)`
```
function\(([a-zA-Z_$][a-zA-Z0-9_$]*)\)
```
2. matches object usage like (`p.T`)
```
([a-zA-Z_$][a-zA-Z0-9_$]*)\.[A-Za-z_$]
```