### PR TITLE
Fix signature regex

### DIFF
--- a/src/consts.rs
+++ b/src/consts.rs
@@ -13,7 +13,7 @@ pub static NSIG_FUNCTION_ARRAYS: &[&str] = &[
 ];
 
 pub static NSIG_FUNCTION_ENDINGS: &[&str] = &[
-    r#"=\s*function(\([\w]+\)\{\s*var\s+[\w\s]+=[\w\.\s]+?\.call\s*\([\w\s$]+?,[\(\)\",\s]+\)[\S\s]*?\}\s*return [\w\.\s$]+?\.call\s*\([\w\s$]+?\s*,[\(\)\",\s]+\)\s*\}\s*;)"#,
+    r#"\s*=function\s*(\(\w\)\s*\{\s*var\s+\w=\w.split.*?\{\s*return"[a-zA-Z0-9_]+.?_w8_".*?\}\s*return\s+\w+\.join\(""\)\s*\}\s*;)"#,
     r#"=\s*function([\S\s]*?\}\s*return \w+?\.join\(\"\"\)\s*\};)"#,
     r#"=\s*function([\S\s]*?\}\s*return [\W\w$]+?\.call\([\w$]+?,\"\"\)\s*\};)"#,
 ];
@@ -21,7 +21,7 @@ pub static NSIG_FUNCTION_ENDINGS: &[&str] = &[
 pub static REGEX_SIGNATURE_TIMESTAMP: &Lazy<Regex> = regex!("signatureTimestamp[=:](\\d+)");
 
 pub static REGEX_SIGNATURE_FUNCTION: &Lazy<Regex> =
-    regex!("\\bc&&\\(c=([a-zA-Z0-9$]{2,})\\(decodeURIComponent\\(c\\)\\)");
+    regex!(r#"\s*?([a-zA-Z0-9_]{1,})=function\([a-zA-Z]{1}\)\{(.{1}=.{1}\.split\(""\)[^\}{]+)return .{1}\.join\(""\)\}"#);
 pub static REGEX_HELPER_OBJ_NAME: &Lazy<Regex> = regex!(";([A-Za-z0-9_\\$]{2,})\\...\\(");
 
 pub static NSIG_FUNCTION_NAME: &str = "decrypt_nsig";

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -34,7 +34,7 @@ pub static REGEX_SIGNATURE_FUNCTION: Lazy<Regex> = Lazy::new(|| {
         r#")"#
     )).unwrap()
 });
-pub static REGEX_HELPER_OBJ_NAME: &Lazy<Regex> = regex!(r"function\(([a-zA-Z_$][a-zA-Z0-9_$]*)\)|([a-zA-Z_$][a-zA-Z0-9_$]*)\.[A-Za-z_$]");
+pub static REGEX_HELPER_OBJ_NAME: &Lazy<Regex> = regex!(r"([A-Za-z0-9_\$]{1,})=function\(");
 
 pub static NSIG_FUNCTION_NAME: &str = "decrypt_nsig";
 pub static SIG_FUNCTION_NAME: &str = "decrypt_sig";

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -20,20 +20,8 @@ pub static NSIG_FUNCTION_ENDINGS: &[&str] = &[
 
 pub static REGEX_SIGNATURE_TIMESTAMP: &Lazy<Regex> = regex!("signatureTimestamp[=:](\\d+)");
 
-pub static REGEX_SIGNATURE_FUNCTION: Lazy<Regex> = Lazy::new(|| {
-    Regex::new(concat!(
-        r#"(?:"#,
-            // Pattern 1
-            r#"\b[a-zA-Z0-9$]+&&\([a-zA-Z0-9$]+=([a-zA-Z0-9$]{2,})\(decodeURIComponent\([a-zA-Z0-9$]+\)\)\)"#,
-            r#"|"#,
-            // Pattern 2
-            r#"([a-zA-Z0-9$]+)\s*=\s*function\(\s*[a-zA-Z0-9$]+\s*\)\s*\{\s*[^}]+?\.split\(\s*""\s*\)[^}]+?\.join\(\s*""\s*\)"#,
-            r#"|"#,
-            // Pattern 3
-            r#"(?:\b|[^a-zA-Z0-9$])([a-zA-Z0-9$]{2,})\s*=\s*function\(\s*a\s*\)\s*\{\s*a\s*=\s*a\.split\(\s*""\s*\)"#,
-        r#")"#
-    )).unwrap()
-});
+pub static REGEX_SIGNATURE_FUNCTION: &Lazy<Regex> =
+    regex!("\\bc&&\\(c=([a-zA-Z0-9$]{2,})\\(decodeURIComponent\\(c\\)\\)");
 pub static REGEX_HELPER_OBJ_NAME: &Lazy<Regex> = regex!(";([A-Za-z0-9_\\$]{2,})\\...\\(");
 
 pub static NSIG_FUNCTION_NAME: &str = "decrypt_nsig";

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -34,7 +34,7 @@ pub static REGEX_SIGNATURE_FUNCTION: Lazy<Regex> = Lazy::new(|| {
         r#")"#
     )).unwrap()
 });
-pub static REGEX_HELPER_OBJ_NAME: &Lazy<Regex> = regex!(r"([A-Za-z0-9_\$]{1,})=function\(");
+pub static REGEX_HELPER_OBJ_NAME: &Lazy<Regex> = regex!(";([A-Za-z0-9_\\$]{2,})\\...\\(");
 
 pub static NSIG_FUNCTION_NAME: &str = "decrypt_nsig";
 pub static SIG_FUNCTION_NAME: &str = "decrypt_sig";

--- a/src/player.rs
+++ b/src/player.rs
@@ -18,12 +18,6 @@ pub enum FetchUpdateStatus {
     CannotFetchPlayerJS,
     NsigRegexCompileFailed,
     PlayerAlreadyUpdated,
-    CannotMatchSignature
-}
-
-fn fixup_n_function_code(code: &str) -> String {
-    let re = regex::Regex::new(r#";\s*if\s*\(\s*typeof\s+[a-zA-Z0-9_$]+\s*===?\s*["']undefined["']\s*\)\s*return\s+[a-zA-Z0-9_$]+;"#).unwrap();
-    re.replace_all(code, ";").to_string()
 }
 
 pub async fn fetch_update(state: Arc<GlobalState>) -> Result<(), FetchUpdateStatus> {
@@ -146,26 +140,18 @@ pub async fn fetch_update(state: Arc<GlobalState>) -> Result<(), FetchUpdateStat
                 i.get(1).unwrap().as_str()
             }
         };
-        nsig_function_code = fixup_n_function_code(&nsig_function_code);
         debug!("got nsig fn code: {}", nsig_function_code);
         break;
     }
 
     // Extract signature function name
-    let sig_function_name = match REGEX_SIGNATURE_FUNCTION.captures(&player_javascript) {
-        Some(captures) => {
-            // Try groups 1, 2, and 3 which contain the signature function name
-            [1, 2, 3].iter()
-                .find_map(|&i| captures.get(i))
-                .map(|m| m.as_str())
-                .ok_or(FetchUpdateStatus::CannotMatchSignature)?
-        }
-        None => {
-            error!("Could not match signature function pattern");
-            return Err(FetchUpdateStatus::CannotMatchSignature);
-        }
-    };
-    debug!("sig function name: {}", sig_function_name);
+    let sig_function_name = REGEX_SIGNATURE_FUNCTION
+        .captures(&player_javascript)
+        .unwrap()
+        .get(1)
+        .unwrap()
+        .as_str();
+
     let mut sig_function_body_regex_str: String = String::new();
     sig_function_body_regex_str += &sig_function_name.replace("$", "\\$");
     sig_function_body_regex_str += "=function\\([a-zA-Z0-9_]+\\)\\{.+?\\}";

--- a/src/player.rs
+++ b/src/player.rs
@@ -182,9 +182,10 @@ pub async fn fetch_update(state: Arc<GlobalState>) -> Result<(), FetchUpdateStat
     // Get the helper object
     let helper_object_name = REGEX_HELPER_OBJ_NAME
         .captures(sig_function_body)
-        .and_then(|cap| cap.get(1).or_else(|| cap.get(2)))
-        .map(|m| m.as_str())
-        .unwrap_or_default();
+        .unwrap()
+        .get(1)
+        .unwrap()
+        .as_str();
 
     let mut helper_object_body_regex_str = String::new();
     helper_object_body_regex_str += "(var ";


### PR DESCRIPTION
Fix signature extraction of player `03dbdfad`.

Tested on the `03dbdfad` player.

Both invidious and sig_helper requests to yt have to be from the same public ip address. Otherwise, the player will be denied access to stream data.

Without specifying visitor_data and po_token, the player only gets `medium`, i.e. itag 18 which has both video and audio stream in one media and quality of 360p.

Other formats can be played after configuring visitor_data and po_token.

This pull request is based on the last @unixfox change, so some new commits have to be reverted.

-----

Fixes #48