### PR TITLE
Add optional socket permissions argument

### DIFF
--- a/src/consts.rs
+++ b/src/consts.rs
@@ -2,6 +2,7 @@ use lazy_regex::{regex, Lazy};
 use regex::Regex;
 
 pub static DEFAULT_SOCK_PATH: &str = "/tmp/inv_sig_helper.sock";
+pub static DEFAULT_SOCK_PERMS: u32 = 0o755;
 pub static DEFAULT_TCP_URL: &str = "127.0.0.1:12999";
 
 pub static TEST_YOUTUBE_VIDEO: &str = "https://www.youtube.com/watch?v=jNQXAC9IVRw";


### PR DESCRIPTION
The default UnixListener permissions (0o755) may not be accessible by invidious when using rootless containers because they mask the UID. 

This PR adds an optional octal argument after the socket path indicating the desired permissions for the socket.