### PR TITLE
Fix for player.rs panic / hardcoded player_id

### DIFF
--- a/src/consts.rs
+++ b/src/consts.rs
@@ -22,7 +22,7 @@ pub static NSIG_FUNCTION_ENDINGS: &[&str] = &[
 pub static REGEX_SIGNATURE_TIMESTAMP: &Lazy<Regex> = regex!("signatureTimestamp[=:](\\d+)");
 
 pub static REGEX_SIGNATURE_FUNCTION: &Lazy<Regex> =
-    regex!(r#"\s*?([a-zA-Z0-9_]{1,})=function\([a-zA-Z]{1}\)\{(.{1}=.{1}\.split\(""\)[^\}{]+)return .{1}\.join\(""\)\}"#);
+    regex!(r#"\s*?([a-zA-Z0-9_\$]{1,})=function\([a-zA-Z]{1}\)\{(.{1}=.{1}\.split\(""\)[^\}{]+)return .{1}\.join\(""\)\}"#);
 pub static REGEX_HELPER_OBJ_NAME: &Lazy<Regex> = regex!(";([A-Za-z0-9_\\$]{2,})\\...\\(");
 
 pub static NSIG_FUNCTION_NAME: &str = "decrypt_nsig";

--- a/src/player.rs
+++ b/src/player.rs
@@ -51,7 +51,7 @@ pub async fn fetch_update(state: Arc<GlobalState>) -> Result<(), FetchUpdateStat
     let mut player_id: u32 = u32::from_str_radix(player_id_str, 16).unwrap();
 
     let mut current_player_info = global_state.player_info.lock().await;
-    let mut current_player_id = current_player_info.player_id;
+    let player_id: u32 = u32::from_str_radix(player_id_str, 16).unwrap();
 
     if player_id == current_player_id {
         current_player_info.last_update = SystemTime::now();

--- a/src/player.rs
+++ b/src/player.rs
@@ -51,7 +51,7 @@ pub async fn fetch_update(state: Arc<GlobalState>) -> Result<(), FetchUpdateStat
     let mut player_id: u32 = u32::from_str_radix(player_id_str, 16).unwrap();
 
     let mut current_player_info = global_state.player_info.lock().await;
-    let current_player_id = current_player_info.player_id;
+    let mut current_player_id = current_player_info.player_id;
 
     if player_id == current_player_id {
         current_player_info.last_update = SystemTime::now();
@@ -59,9 +59,6 @@ pub async fn fetch_update(state: Arc<GlobalState>) -> Result<(), FetchUpdateStat
     }
     // release the mutex for other tasks
     drop(current_player_info);
-
-    // temp workaround
-    player_id = 0xf3d47b5a;
     
     // Download the player script
     let player_js_url: String = format!(

--- a/src/player.rs
+++ b/src/player.rs
@@ -48,7 +48,7 @@ pub async fn fetch_update(state: Arc<GlobalState>) -> Result<(), FetchUpdateStat
         None => return Err(FetchUpdateStatus::CannotMatchPlayerID),
     };
 
-    let mut player_id: u32 = u32::from_str_radix(player_id_str, 16).unwrap();
+    let player_id: u32 = u32::from_str_radix(player_id_str, 16).unwrap();
 
     let mut current_player_info = global_state.player_info.lock().await;
     let current_player_id = current_player_info.player_id;

--- a/src/player.rs
+++ b/src/player.rs
@@ -51,7 +51,7 @@ pub async fn fetch_update(state: Arc<GlobalState>) -> Result<(), FetchUpdateStat
     let mut player_id: u32 = u32::from_str_radix(player_id_str, 16).unwrap();
 
     let mut current_player_info = global_state.player_info.lock().await;
-    let player_id: u32 = u32::from_str_radix(player_id_str, 16).unwrap();
+    let current_player_id = current_player_info.player_id;
 
     if player_id == current_player_id {
         current_player_info.last_update = SystemTime::now();


### PR DESCRIPTION
This should be a fix for the temporary workaround of hardcoding the older player ID.

It looks like it was caused by the regex not properly matching function names with $ in them, tested it on the player ID that wasn't working for me before (af7f576f) and the new current one I'm getting (074a8365).

Fixes issue #58 / #59 
Reverts temporary changes from PR #61 