### PR TITLE
Fix player.rs regex failing to match when helper_object_name contains $

### DIFF
--- a/src/player.rs
+++ b/src/player.rs
@@ -168,7 +168,7 @@ pub async fn fetch_update(state: Arc<GlobalState>) -> Result<(), FetchUpdateStat
         .as_str();
 
     let mut sig_function_body_regex_str: String = String::new();
-    sig_function_body_regex_str += sig_function_name;
+    sig_function_body_regex_str += &sig_function_name.replace("$", "\\$");
     sig_function_body_regex_str += "=function\\([a-zA-Z0-9_]+\\)\\{.+?\\}";
 
     let sig_function_body_regex = Regex::new(&sig_function_body_regex_str).unwrap();

--- a/src/player.rs
+++ b/src/player.rs
@@ -190,10 +190,13 @@ pub async fn fetch_update(state: Arc<GlobalState>) -> Result<(), FetchUpdateStat
 
     let mut helper_object_body_regex_str = String::new();
     helper_object_body_regex_str += "(var ";
-    helper_object_body_regex_str += helper_object_name;
+    helper_object_body_regex_str += &helper_object_name.replace("$", "\\$");
     helper_object_body_regex_str += "=\\{(?:.|\\n)+?\\}\\};)";
 
     let helper_object_body_regex = Regex::new(&helper_object_body_regex_str).unwrap();
+
+    println!("{helper_object_body_regex_str}");
+
     let helper_object_body = helper_object_body_regex
         .captures(&player_javascript)
         .unwrap()

--- a/src/player.rs
+++ b/src/player.rs
@@ -168,7 +168,7 @@ pub async fn fetch_update(state: Arc<GlobalState>) -> Result<(), FetchUpdateStat
         .as_str();
 
     let mut sig_function_body_regex_str: String = String::new();
-    sig_function_body_regex_str += &sig_function_name.replace("$", "\\$");
+    sig_function_body_regex_str += sig_function_name;
     sig_function_body_regex_str += "=function\\([a-zA-Z0-9_]+\\)\\{.+?\\}";
 
     let sig_function_body_regex = Regex::new(&sig_function_body_regex_str).unwrap();

--- a/src/player.rs
+++ b/src/player.rs
@@ -194,9 +194,6 @@ pub async fn fetch_update(state: Arc<GlobalState>) -> Result<(), FetchUpdateStat
     helper_object_body_regex_str += "=\\{(?:.|\\n)+?\\}\\};)";
 
     let helper_object_body_regex = Regex::new(&helper_object_body_regex_str).unwrap();
-
-    println!("{helper_object_body_regex_str}");
-
     let helper_object_body = helper_object_body_regex
         .captures(&player_javascript)
         .unwrap()


### PR DESCRIPTION
if the helper_object_name contains a $ it wasn't escaped, so the next match would fail causing a crash.

`thread 'main' panicked at src/player.rs:199:10:
called `Option::unwrap()` on a `None` value
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace`

new player ID that caused this issue: c548b3da

