### PR TITLE
Add yt-dlp support for signature decoding (optional)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+cached = "0.27"
 regex = "1.10.4"
 tokio = { version = "1.37.0", features = ["full", "net", "macros", "rt-multi-thread", "io-std", "io-util", "mio"] }
 reqwest = "0.12.4"

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,13 @@ RUN apk add --no-cache \
     pkgconfig \
     patch
 
+# Install python3 for ytdlp
+RUN apk add --no-cache python3 py3-pip
+
+# Install yt-dlp
+RUN pip3 install yt-dlp
+
+
 # Set environment variables for static linking
 ENV OPENSSL_STATIC=yes
 ENV OPENSSL_DIR=/usr
@@ -35,6 +42,10 @@ FROM scratch
 # Copy necessary files from the builder stage, using the correct architecture path
 COPY --from=builder /usr/src/app/target/*/release/inv_sig_helper_rust /app/inv_sig_helper_rust
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+
+# Copy scripts and make them executable
+COPY --from=builder /usr/src/app/scripts /app/scripts
+RUN chmod +x /app/scripts/*
 
 # Copy passwd file for the non-privileged user from the user-stage
 COPY --from=user-stage /etc/passwd /etc/passwd

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN apk add --no-cache \
 RUN apk add --no-cache python3 py3-pip
 
 # Install yt-dlp
-RUN pip3 install yt-dlp
+RUN pip3 install --break-system-packages yt-dlp
 
 
 # Set environment variables for static linking

--- a/Dockerfile
+++ b/Dockerfile
@@ -47,10 +47,6 @@ COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 # Copy scripts
 COPY --from=builder /usr/src/app/src/scripts /app/scripts
 
-
-# Copy passwd file for the non-privileged user from the user-stage
-COPY --from=user-stage /etc/passwd /etc/passwd
-
 # Set the working directory
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,13 +12,6 @@ RUN apk add --no-cache \
     pkgconfig \
     patch
 
-# Install python3 for ytdlp
-RUN apk add --no-cache python3 py3-pip
-
-# Install yt-dlp
-RUN pip3 install --break-system-packages yt-dlp
-
-
 # Set environment variables for static linking
 ENV OPENSSL_STATIC=yes
 ENV OPENSSL_DIR=/usr
@@ -35,12 +28,17 @@ RUN RUST_TARGET=$(rustc -vV | sed -n 's/host: //p') && \
     RUSTFLAGS='-C target-feature=+crt-static' cargo build --release --target $RUST_TARGET
 
 # Stage for creating the non-privileged user
-FROM alpine:3.20 AS user-stage
+FROM alpine:3.20
+
+RUN apk add coreutils
+
+# Install python3 for ytdlp
+RUN apk add --no-cache python3 py3-pip
+
+# Install yt-dlp
+RUN pip3 install --break-system-packages yt-dlp
 
 RUN adduser -u 10001 -S appuser
-
-# Stage for a smaller final image
-FROM scratch
 
 # Copy necessary files from the builder stage, using the correct architecture path
 COPY --from=builder /usr/src/app/target/*/release/inv_sig_helper_rust /app/inv_sig_helper_rust

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,9 @@ ENV OPENSSL_DIR=/usr
 # Copy the current directory contents into the container
 COPY . .
 
+# make sure the scripts are executable
+RUN chmod +x src/scripts/*
+
 # Determine the target architecture and build the application
 RUN RUST_TARGET=$(rustc -vV | sed -n 's/host: //p') && \
     rustup target add $RUST_TARGET && \
@@ -43,9 +46,9 @@ FROM scratch
 COPY --from=builder /usr/src/app/target/*/release/inv_sig_helper_rust /app/inv_sig_helper_rust
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 
-# Copy scripts and make them executable
-COPY --from=builder /usr/src/app/scripts /app/scripts
-RUN chmod +x /app/scripts/*
+# Copy scripts
+COPY --from=builder /usr/src/app/src/scripts /app/scripts
+
 
 # Copy passwd file for the non-privileged user from the user-stage
 COPY --from=user-stage /etc/passwd /etc/passwd

--- a/README.md
+++ b/README.md
@@ -93,6 +93,29 @@ The service can run in Unix socket mode (default) or TCP mode:
 
    If no IP:PORT is given, it defaults to `127.0.0.1:12999`.
 
+#### yt-dlp decoding
+
+`inv_sig_helper` supports signature decoding using `yt-dlp`. This feature can be useful if you want to use `yt-dlp` for decoding signatures instead of the built-in code.
+
+To enable decoding using `yt-dlp`, set the environment variable `USE_YT_DLP` to `1`:
+
+```
+export USE_YT_DLP=1
+```
+
+or uncomment the following line in your `docker-compose.yaml`:
+
+```yaml
+environment:
+  - USE_YT_DLP=1  # use yt-dlp for decoding signatures instead of built-in code
+```
+
+inv_sig_helper.service:
+
+```
+Environment="USE_YT_DLP=1"
+```
+
 #### Troubleshooting
 
 The log level can be configured using the `RUST_LOG` environment variable. Valid values are:
@@ -104,6 +127,8 @@ The log level can be configured using the `RUST_LOG` environment variable. Valid
 - trace
 
 The `info` log level is the default setting. Changing this to `debug` will provide detailed logs on each request for additional troubleshooting.
+
+In case of issues with decoding / `sig` function / `nsig` function, refer to the `yt-dlp decoding` section.
 
 
 ## Protocol Format

--- a/README.md
+++ b/README.md
@@ -116,6 +116,12 @@ inv_sig_helper.service:
 Environment="USE_YT_DLP=1"
 ```
 
+To upgrade `yt-dlp` in the container, you need to rebuild the Docker container:
+
+```
+docker compose up --build --force-recreate --no-deps
+```
+
 #### Troubleshooting
 
 The log level can be configured using the `RUST_LOG` environment variable. Valid values are:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -12,10 +12,11 @@ services:
     environment:
       - RUST_LOG=info
       # - USE_YT_DLP=1
+      # use yt-dlp for decoding signatures instead of bulit-in code
     restart: unless-stopped
     cap_drop:
       - ALL
-    read_only: true
+    read_only: false # yt-dlp cache
     user: 10001:10001
     security_opt:
       - no-new-privileges:true

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,6 +11,7 @@ services:
       - 127.0.0.1:12999:12999
     environment:
       - RUST_LOG=info
+      # - USE_YT_DLP=1
     restart: unless-stopped
     cap_drop:
       - ALL

--- a/inv_sig_helper.service
+++ b/inv_sig_helper.service
@@ -10,6 +10,9 @@ Type=simple
 User=invidious
 Group=invidious
 
+# use yt-dlp for decoding signatures instead of bulit-in code
+# Environment="USE_YT_DLP=1"
+
 # allow only the strict necessary since this service runs untrusted code directly from Google
 CapabilityBoundingSet=~CAP_SETUID CAP_SETGID CAP_SETPCAP
 CapabilityBoundingSet=~CAP_SYS_ADMIN

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -5,7 +5,8 @@ pub static DEFAULT_SOCK_PATH: &str = "/tmp/inv_sig_helper.sock";
 pub static DEFAULT_SOCK_PERMS: u32 = 0o755;
 pub static DEFAULT_TCP_URL: &str = "127.0.0.1:12999";
 
-pub static TEST_YOUTUBE_VIDEO: &str = "https://www.youtube.com/watch?v=jNQXAC9IVRw";
+pub static TEST_YOUTUBE_VIDEO_ID: &str = "jNQXAC9IVRw";
+pub static TEST_YOUTUBE_VIDEO: &str = concat!("https://www.youtube.com/watch?v=", TEST_YOUTUBE_VIDEO_ID);
 
 pub static REGEX_PLAYER_ID: &Lazy<Regex> = regex!("\\/s\\/player\\/([0-9a-f]{8})");
 pub static NSIG_FUNCTION_ARRAYS: &[&str] = &[
@@ -27,3 +28,5 @@ pub static REGEX_HELPER_OBJ_NAME: &Lazy<Regex> = regex!(";([A-Za-z0-9_\\$]{2,})\
 
 pub static NSIG_FUNCTION_NAME: &str = "decrypt_nsig";
 pub static SIG_FUNCTION_NAME: &str = "decrypt_sig";
+
+pub static ENV_USE_YT_DLP: &str = "USE_YT_DLP";

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -6,7 +6,7 @@ pub static DEFAULT_SOCK_PERMS: u32 = 0o755;
 pub static DEFAULT_TCP_URL: &str = "127.0.0.1:12999";
 
 pub static TEST_YOUTUBE_VIDEO_ID: &str = "jNQXAC9IVRw";
-pub static TEST_YOUTUBE_VIDEO: &str = concat!("https://www.youtube.com/watch?v=", TEST_YOUTUBE_VIDEO_ID);
+pub static TEST_YOUTUBE_VIDEO: &str = "https://www.youtube.com/watch?v=jNQXAC9IVRw";
 
 pub static REGEX_PLAYER_ID: &Lazy<Regex> = regex!("\\/s\\/player\\/([0-9a-f]{8})");
 pub static NSIG_FUNCTION_ARRAYS: &[&str] = &[

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod consts;
 mod jobs;
 mod opcode;
 mod player;
+mod ytdlp; 
 
 use ::futures::StreamExt;
 use consts::{DEFAULT_SOCK_PATH, DEFAULT_SOCK_PERMS, DEFAULT_TCP_URL};

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,6 +56,10 @@ async fn main() {
         None => DEFAULT_SOCK_PATH,
     };
 
+    if ytdlp_requested() {
+        info!("Using yt-dlp for signature decryption");
+    }
+
     // have to please rust
     let state: Arc<GlobalState> = Arc::new(GlobalState::new());
 

--- a/src/player.rs
+++ b/src/player.rs
@@ -8,9 +8,8 @@ use crate::{
         REGEX_PLAYER_ID, REGEX_SIGNATURE_FUNCTION, REGEX_SIGNATURE_TIMESTAMP, TEST_YOUTUBE_VIDEO,
     },
     jobs::GlobalState,
+    ytdlp::{ytdlp_requested, ytdlp_signature_timestamp};
 };
-
-use ytdlp::{ytdlp_requested, ytdlp_signature_timestamp};
 
 // TODO: too lazy to make proper debugging print
 #[derive(Debug)]

--- a/src/player.rs
+++ b/src/player.rs
@@ -8,7 +8,7 @@ use crate::{
         REGEX_PLAYER_ID, REGEX_SIGNATURE_FUNCTION, REGEX_SIGNATURE_TIMESTAMP, TEST_YOUTUBE_VIDEO,
     },
     jobs::GlobalState,
-    ytdlp::{ytdlp_requested, ytdlp_signature_timestamp};
+    ytdlp::{ytdlp_requested, ytdlp_signature_timestamp},
 };
 
 // TODO: too lazy to make proper debugging print

--- a/src/scripts/common.py
+++ b/src/scripts/common.py
@@ -1,0 +1,10 @@
+import os, sys
+
+class HiddenPrints:
+    def __enter__(self):
+        self._original_stdout = sys.stdout
+        sys.stdout = open(os.devnull, 'w')
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        sys.stdout.close()
+        sys.stdout = self._original_stdout

--- a/src/scripts/yt-dlp_nsig_decoder.py
+++ b/src/scripts/yt-dlp_nsig_decoder.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import yt_dlp.YoutubeDL
+import yt_dlp.extractor.youtube
+import sys
+import os
+import json
+
+"""
+Args:
+    - sys.argv[1]: player_url
+    - sys.argv[2]: signature
+Example:
+    python yt-dlp_nsig_decoder.py "https://www.youtube.com/s/player/af7f576f/player_ias.vflset/en_US/base.js" "W78n255zM6g"
+"""
+
+params = {}
+
+YOUTUBE_VIDEO_ID = "W78n255zM6g"
+
+ie = yt_dlp.extractor.YoutubeIE()
+ydl = yt_dlp.YoutubeDL({})
+ydl.add_info_extractor(ie)
+
+player_url = sys.argv[1]
+signature = sys.argv[2]
+print(type(signature))
+
+print(ie._decrypt_nsig(signature, YOUTUBE_VIDEO_ID, player_url))

--- a/src/scripts/yt-dlp_nsig_decoder.py
+++ b/src/scripts/yt-dlp_nsig_decoder.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import yt_dlp.YoutubeDL

--- a/src/scripts/yt-dlp_nsig_decoder.py
+++ b/src/scripts/yt-dlp_nsig_decoder.py
@@ -4,8 +4,6 @@
 import yt_dlp.YoutubeDL
 import yt_dlp.extractor.youtube
 import sys
-import os
-import json
 
 """
 Args:

--- a/src/scripts/yt-dlp_nsig_decoder.py
+++ b/src/scripts/yt-dlp_nsig_decoder.py
@@ -24,4 +24,4 @@ player_url = sys.argv[1]
 signature = sys.argv[2]
 youtube_video_id = sys.argv[3]
 
-print(ie._decrypt_nsig(signature, youtube_video_id, player_url))
+print(ie._decrypt_nsig(signature, youtube_video_id, player_url), end='')

--- a/src/scripts/yt-dlp_nsig_decoder.py
+++ b/src/scripts/yt-dlp_nsig_decoder.py
@@ -9,13 +9,12 @@ import sys
 Args:
     - sys.argv[1]: player_url
     - sys.argv[2]: signature
+    - sys.argv[3]: random youtube video id
 Example:
-    python yt-dlp_nsig_decoder.py "https://www.youtube.com/s/player/af7f576f/player_ias.vflset/en_US/base.js" "W78n255zM6g"
+    python yt-dlp_nsig_decoder.py "https://www.youtube.com/s/player/af7f576f/player_ias.vflset/en_US/base.js" "W78n255zM6g" "W78n255zM6g"
 """
 
 params = {}
-
-YOUTUBE_VIDEO_ID = "W78n255zM6g"
 
 ie = yt_dlp.extractor.YoutubeIE()
 ydl = yt_dlp.YoutubeDL({})
@@ -23,6 +22,6 @@ ydl.add_info_extractor(ie)
 
 player_url = sys.argv[1]
 signature = sys.argv[2]
-print(type(signature))
+youtube_video_id = sys.argv[3]
 
-print(ie._decrypt_nsig(signature, YOUTUBE_VIDEO_ID, player_url))
+print(ie._decrypt_nsig(signature, youtube_video_id, player_url))

--- a/src/scripts/yt-dlp_nsig_decoder.py
+++ b/src/scripts/yt-dlp_nsig_decoder.py
@@ -4,6 +4,7 @@
 import yt_dlp.YoutubeDL
 import yt_dlp.extractor.youtube
 import sys
+from common import HiddenPrints
 
 """
 Args:
@@ -14,14 +15,17 @@ Example:
     python yt-dlp_nsig_decoder.py "https://www.youtube.com/s/player/af7f576f/player_ias.vflset/en_US/base.js" "W78n255zM6g" "W78n255zM6g"
 """
 
-params = {}
+with HiddenPrints():
+    params = {}
 
-ie = yt_dlp.extractor.YoutubeIE()
-ydl = yt_dlp.YoutubeDL({})
-ydl.add_info_extractor(ie)
+    ie = yt_dlp.extractor.YoutubeIE()
+    ydl = yt_dlp.YoutubeDL({})
+    ydl.add_info_extractor(ie)
 
-player_url = sys.argv[1]
-signature = sys.argv[2]
-youtube_video_id = sys.argv[3]
+    player_url = sys.argv[1]
+    signature = sys.argv[2]
+    youtube_video_id = sys.argv[3]
+    
+    output = ie._decrypt_nsig(signature, youtube_video_id, player_url)
 
-print(ie._decrypt_nsig(signature, youtube_video_id, player_url), end='')
+print(output, end='')

--- a/src/scripts/yt-dlp_sig_decoder.py
+++ b/src/scripts/yt-dlp_sig_decoder.py
@@ -24,4 +24,4 @@ player_url = sys.argv[1]
 signature = sys.argv[2]
 youtube_video_id = sys.argv[3]
 
-print(ie._decrypt_signature(signature, youtube_video_id, player_url))
+print(ie._decrypt_signature(signature, youtube_video_id, player_url), end='')

--- a/src/scripts/yt-dlp_sig_decoder.py
+++ b/src/scripts/yt-dlp_sig_decoder.py
@@ -4,6 +4,7 @@
 import yt_dlp.YoutubeDL
 import yt_dlp.extractor.youtube
 import sys
+from common import HiddenPrints
 
 """
 Args:
@@ -14,14 +15,16 @@ Example:
     python yt-dlp_sig_decoder.py "https://www.youtube.com/s/player/af7f576f/player_ias.vflset/en_US/base.js" "W78n255zM6g" "W78n255zM6g"
 """
 
-params = {}
+with HiddenPrints():
+    params = {}
 
-ie = yt_dlp.extractor.YoutubeIE()
-ydl = yt_dlp.YoutubeDL({})
-ydl.add_info_extractor(ie)
+    ie = yt_dlp.extractor.YoutubeIE()
+    ydl = yt_dlp.YoutubeDL({})
+    ydl.add_info_extractor(ie)
 
-player_url = sys.argv[1]
-signature = sys.argv[2]
-youtube_video_id = sys.argv[3]
+    player_url = sys.argv[1]
+    signature = sys.argv[2]
+    youtube_video_id = sys.argv[3]
+    output = ie._decrypt_signature(signature, youtube_video_id, player_url)
 
-print(ie._decrypt_signature(signature, youtube_video_id, player_url), end='')
+print(output, end='')

--- a/src/scripts/yt-dlp_sig_decoder.py
+++ b/src/scripts/yt-dlp_sig_decoder.py
@@ -9,13 +9,12 @@ import sys
 Args:
     - sys.argv[1]: player_url
     - sys.argv[2]: signature
+    - sys.argv[3]: random youtube video id
 Example:
-    python yt-dlp_sig_decoder.py "https://www.youtube.com/s/player/af7f576f/player_ias.vflset/en_US/base.js" "W78n255zM6g"
+    python yt-dlp_sig_decoder.py "https://www.youtube.com/s/player/af7f576f/player_ias.vflset/en_US/base.js" "W78n255zM6g" "W78n255zM6g"
 """
 
 params = {}
-
-YOUTUBE_VIDEO_ID = "W78n255zM6g"
 
 ie = yt_dlp.extractor.YoutubeIE()
 ydl = yt_dlp.YoutubeDL({})
@@ -23,6 +22,6 @@ ydl.add_info_extractor(ie)
 
 player_url = sys.argv[1]
 signature = sys.argv[2]
-print(type(signature))
+youtube_video_id = sys.argv[3]
 
-print(ie._decrypt_signature(signature, YOUTUBE_VIDEO_ID, player_url))
+print(ie._decrypt_signature(signature, youtube_video_id, player_url))

--- a/src/scripts/yt-dlp_sig_decoder.py
+++ b/src/scripts/yt-dlp_sig_decoder.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import yt_dlp.YoutubeDL

--- a/src/scripts/yt-dlp_sig_decoder.py
+++ b/src/scripts/yt-dlp_sig_decoder.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import yt_dlp.YoutubeDL
+import yt_dlp.extractor.youtube
+import sys
+
+"""
+Args:
+    - sys.argv[1]: player_url
+    - sys.argv[2]: signature
+Example:
+    python yt-dlp_sig_decoder.py "https://www.youtube.com/s/player/af7f576f/player_ias.vflset/en_US/base.js" "W78n255zM6g"
+"""
+
+params = {}
+
+YOUTUBE_VIDEO_ID = "W78n255zM6g"
+
+ie = yt_dlp.extractor.YoutubeIE()
+ydl = yt_dlp.YoutubeDL({})
+ydl.add_info_extractor(ie)
+
+player_url = sys.argv[1]
+signature = sys.argv[2]
+print(type(signature))
+
+print(ie._decrypt_signature(signature, YOUTUBE_VIDEO_ID, player_url))

--- a/src/scripts/yt-dlp_signature_timestamp.py
+++ b/src/scripts/yt-dlp_signature_timestamp.py
@@ -23,4 +23,4 @@ ydl.add_info_extractor(ie)
 player_url = sys.argv[1]
 youtube_video_id = sys.argv[2]
 
-print(ie._extract_signature_timestamp(youtube_video_id, player_url))
+print(ie._extract_signature_timestamp(youtube_video_id, player_url), end='')

--- a/src/scripts/yt-dlp_signature_timestamp.py
+++ b/src/scripts/yt-dlp_signature_timestamp.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import yt_dlp.YoutubeDL
+import yt_dlp.extractor.youtube
+import sys
+
+"""
+Args:
+    - sys.argv[1]: player_url
+    - sys.argv[2]: random youtube video id
+Example:
+    python yt-dlp_sig_decoder.py "https://www.youtube.com/s/player/af7f576f/player_ias.vflset/en_US/base.js" "W78n255zM6g"
+"""
+
+
+params = {}
+
+ie = yt_dlp.extractor.YoutubeIE()
+ydl = yt_dlp.YoutubeDL({})
+ydl.add_info_extractor(ie)
+
+player_url = sys.argv[1]
+youtube_video_id = sys.argv[2]
+
+print(ie._extract_signature_timestamp(youtube_video_id, player_url))

--- a/src/scripts/yt-dlp_signature_timestamp.py
+++ b/src/scripts/yt-dlp_signature_timestamp.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 import yt_dlp.YoutubeDL

--- a/src/scripts/yt-dlp_signature_timestamp.py
+++ b/src/scripts/yt-dlp_signature_timestamp.py
@@ -4,23 +4,26 @@
 import yt_dlp.YoutubeDL
 import yt_dlp.extractor.youtube
 import sys
+from common import HiddenPrints
 
 """
 Args:
     - sys.argv[1]: player_url
     - sys.argv[2]: random youtube video id
 Example:
-    python yt-dlp_sig_decoder.py "https://www.youtube.com/s/player/af7f576f/player_ias.vflset/en_US/base.js" "W78n255zM6g"
+    python yt-dlp_signature_timestamp.py "https://www.youtube.com/s/player/af7f576f/player_ias.vflset/en_US/base.js" "W78n255zM6g"
 """
 
+with HiddenPrints():
+    params = {}
 
-params = {}
+    ie = yt_dlp.extractor.YoutubeIE()
+    ydl = yt_dlp.YoutubeDL({})
+    ydl.add_info_extractor(ie)
 
-ie = yt_dlp.extractor.YoutubeIE()
-ydl = yt_dlp.YoutubeDL({})
-ydl.add_info_extractor(ie)
+    player_url = sys.argv[1]
+    youtube_video_id = sys.argv[2]
 
-player_url = sys.argv[1]
-youtube_video_id = sys.argv[2]
+    output = ie._extract_signature_timestamp(youtube_video_id, player_url)
 
-print(ie._extract_signature_timestamp(youtube_video_id, player_url), end='')
+print(output, end='')

--- a/src/ytdlp.rs
+++ b/src/ytdlp.rs
@@ -5,7 +5,7 @@ use std::env;
 use std::path::PathBuf;
 use std::process::Command;
 
-use consts::{ENV_USE_YT_DLP, "TEST_YOUTUBE_VIDEO"};
+use consts::{ENV_USE_YT_DLP, TEST_YOUTUBE_VIDEO};
 
 fn ytdlp_get_script_path(script_name: &str) -> PathBuf {
     let exe_path = std::env::current_exe().expect("Failed to get current path of binary");
@@ -13,14 +13,14 @@ fn ytdlp_get_script_path(script_name: &str) -> PathBuf {
     exe_dir.join("scripts").join(script_name)
 }
 
-fn ytdlp_requested() -> bool {
+pub fn ytdlp_requested() -> bool {
     match std::env::var(ENV_USE_YT_DLP) {
         Ok(val) => val == "1",
         Err(_) => false,
     }
 }
 
-fn ytdlp_signature_timestamp(player_id: u32) -> u64 {
+pub fn ytdlp_signature_timestamp(player_id: u32) -> u64 {
     let player_js_url: String = format!(
         "https://www.youtube.com/s/player/{:08x}/player_ias.vflset/en_US/base.js",
         player_id
@@ -35,7 +35,7 @@ fn ytdlp_signature_timestamp(player_id: u32) -> u64 {
     output.to_string().parse::<u64>().unwrap()
 }
 
-fn ytdlp_nsig_decoder(signature: &str, player_id: u32) -> String {
+pub fn ytdlp_nsig_decoder(signature: &str, player_id: u32) -> String {
     let player_js_url: String = format!(
         "https://www.youtube.com/s/player/{:08x}/player_ias.vflset/en_US/base.js",
         player_id
@@ -51,7 +51,7 @@ fn ytdlp_nsig_decoder(signature: &str, player_id: u32) -> String {
     output.to_string()
 }
 
-fn ytdlp_sig_decoder(signature: &str, player_id: u32) -> String {
+pub fn ytdlp_sig_decoder(signature: &str, player_id: u32) -> String {
     let player_js_url: String = format!(
         "https://www.youtube.com/s/player/{:08x}/player_ias.vflset/en_US/base.js",
         player_id

--- a/src/ytdlp.rs
+++ b/src/ytdlp.rs
@@ -22,7 +22,7 @@ pub fn ytdlp_signature_timestamp(player_id: u32) -> u64 {
         "https://www.youtube.com/s/player/{:08x}/player_ias.vflset/en_US/base.js",
         player_id
     );
-    let child = std::process::Command::new(ytdlp_get_script_path("ytdlp_signature_timestamp.py"))
+    let child = std::process::Command::new(ytdlp_get_script_path("yt-dlp_signature_timestamp.py"))
         .arg(player_js_url)
         .arg(TEST_YOUTUBE_VIDEO)
         .output()
@@ -37,7 +37,7 @@ pub fn ytdlp_nsig_decoder(signature: &str, player_id: u32) -> String {
         "https://www.youtube.com/s/player/{:08x}/player_ias.vflset/en_US/base.js",
         player_id
     );
-    let child = std::process::Command::new(ytdlp_get_script_path("ytdlp_nsig_decoder.py"))
+    let child = std::process::Command::new(ytdlp_get_script_path("yt-dlp_nsig_decoder.py"))
         .arg(player_js_url)
         .arg(signature)
         .arg(TEST_YOUTUBE_VIDEO)
@@ -53,7 +53,7 @@ pub fn ytdlp_sig_decoder(signature: &str, player_id: u32) -> String {
         "https://www.youtube.com/s/player/{:08x}/player_ias.vflset/en_US/base.js",
         player_id
     );
-    let child = std::process::Command::new(ytdlp_get_script_path("ytdlp_sig_decoder.py"))
+    let child = std::process::Command::new(ytdlp_get_script_path("yt-dlp_sig_decoder.py"))
         .arg(player_js_url)
         .arg(signature)
         .arg(TEST_YOUTUBE_VIDEO)

--- a/src/ytdlp.rs
+++ b/src/ytdlp.rs
@@ -1,7 +1,8 @@
 use std::path::PathBuf;
 use std::process::Command;
+use cached::proc_macro::cached;
 
-use crate::consts::{ENV_USE_YT_DLP, TEST_YOUTUBE_VIDEO};
+use crate::consts::{ENV_USE_YT_DLP, TEST_YOUTUBE_VIDEO_ID};
 
 fn ytdlp_get_script_path(script_name: &str) -> PathBuf {
     let exe_path = std::env::current_exe().expect("Failed to get current path of binary");
@@ -16,6 +17,7 @@ pub fn ytdlp_requested() -> bool {
     }
 }
 
+#[cached(size = 100)]
 pub fn ytdlp_signature_timestamp(player_id: u32) -> u64 {
     let player_js_url: String = format!(
         "https://www.youtube.com/s/player/{:08x}/player_ias.vflset/en_US/base.js",
@@ -23,7 +25,7 @@ pub fn ytdlp_signature_timestamp(player_id: u32) -> u64 {
     );
     let child = std::process::Command::new(ytdlp_get_script_path("yt-dlp_signature_timestamp.py"))
         .arg(player_js_url)
-        .arg(TEST_YOUTUBE_VIDEO)
+        .arg(TEST_YOUTUBE_VIDEO_ID)
         .output()
         .expect("Failed to execute command");
 
@@ -31,7 +33,8 @@ pub fn ytdlp_signature_timestamp(player_id: u32) -> u64 {
     output.to_string().parse::<u64>().unwrap()
 }
 
-pub fn ytdlp_nsig_decoder(signature: &str, player_id: u32) -> String {
+#[cached(size = 10000)]
+pub fn ytdlp_nsig_decoder(signature: String, player_id: u32) -> String {
     let player_js_url: String = format!(
         "https://www.youtube.com/s/player/{:08x}/player_ias.vflset/en_US/base.js",
         player_id
@@ -39,7 +42,7 @@ pub fn ytdlp_nsig_decoder(signature: &str, player_id: u32) -> String {
     let child = std::process::Command::new(ytdlp_get_script_path("yt-dlp_nsig_decoder.py"))
         .arg(player_js_url)
         .arg(signature)
-        .arg(TEST_YOUTUBE_VIDEO)
+        .arg(TEST_YOUTUBE_VIDEO_ID)
         .output()
         .expect("Failed to execute command");
 
@@ -47,7 +50,8 @@ pub fn ytdlp_nsig_decoder(signature: &str, player_id: u32) -> String {
     output.to_string()
 }
 
-pub fn ytdlp_sig_decoder(signature: &str, player_id: u32) -> String {
+#[cached(size = 10000)]
+pub fn ytdlp_sig_decoder(signature: String, player_id: u32) -> String {
     let player_js_url: String = format!(
         "https://www.youtube.com/s/player/{:08x}/player_ias.vflset/en_US/base.js",
         player_id
@@ -55,7 +59,7 @@ pub fn ytdlp_sig_decoder(signature: &str, player_id: u32) -> String {
     let child = std::process::Command::new(ytdlp_get_script_path("yt-dlp_sig_decoder.py"))
         .arg(player_js_url)
         .arg(signature)
-        .arg(TEST_YOUTUBE_VIDEO)
+        .arg(TEST_YOUTUBE_VIDEO_ID)
         .output()
         .expect("Failed to execute command");
 

--- a/src/ytdlp.rs
+++ b/src/ytdlp.rs
@@ -1,8 +1,17 @@
 mod consts;
 
 use ::futures::StreamExt;
+use std::env;
+use std::path::PathBuf;
+use std::process::Command;
 
 use consts::{ENV_USE_YT_DLP, "TEST_YOUTUBE_VIDEO"};
+
+fn ytdlp_get_script_path(script_name: &str) -> PathBuf {
+    let exe_path = std::env::current_exe().expect("Failed to get current path of binary");
+    let exe_dir = exe_path.parent().expect("Failed to get current path of binary");
+    exe_dir.join("scripts").join(script_name)
+}
 
 fn ytdlp_requested() -> bool {
     match std::env::var(ENV_USE_YT_DLP) {
@@ -16,7 +25,7 @@ fn ytdlp_signature_timestamp(player_id: u32) -> u64 {
         "https://www.youtube.com/s/player/{:08x}/player_ias.vflset/en_US/base.js",
         player_id
     );
-    let mut child = std::process::Command::new("src/ytdlp_signature_timestamp.py")
+    let mut child = std::process::Command::new(ytdlp_get_script_path("ytdlp_signature_timestamp.py"))
         .arg(player_js_url)
         .arg(TEST_YOUTUBE_VIDEO)
         .output()
@@ -31,7 +40,7 @@ fn ytdlp_nsig_decoder(signature: &str, player_id: u32) -> String {
         "https://www.youtube.com/s/player/{:08x}/player_ias.vflset/en_US/base.js",
         player_id
     );
-    let mut child = std::process::Command::new("src/ytdlp_nsig_decoder.py")
+    let mut child = std::process::Command::new(ytdlp_get_script_path("ytdlp_nsig_decoder.py"))
         .arg(player_js_url)
         .arg(signature)
         .arg(TEST_YOUTUBE_VIDEO)
@@ -47,7 +56,7 @@ fn ytdlp_sig_decoder(signature: &str, player_id: u32) -> String {
         "https://www.youtube.com/s/player/{:08x}/player_ias.vflset/en_US/base.js",
         player_id
     );
-    let mut child = std::process::Command::new("src/ytdlp_sig_decoder.py")
+    let mut child = std::process::Command::new(ytdlp_get_script_path("ytdlp_sig_decoder.py"))
         .arg(player_js_url)
         .arg(signature)
         .arg(TEST_YOUTUBE_VIDEO)

--- a/src/ytdlp.rs
+++ b/src/ytdlp.rs
@@ -1,6 +1,5 @@
-use std::env::var;
 use std::path::PathBuf;
-use std::process::Command::new;
+use std::process::Command;
 
 use crate::consts::{ENV_USE_YT_DLP, TEST_YOUTUBE_VIDEO};
 

--- a/src/ytdlp.rs
+++ b/src/ytdlp.rs
@@ -22,7 +22,7 @@ pub fn ytdlp_signature_timestamp(player_id: u32) -> u64 {
         "https://www.youtube.com/s/player/{:08x}/player_ias.vflset/en_US/base.js",
         player_id
     );
-    let mut child = std::process::Command::new(ytdlp_get_script_path("ytdlp_signature_timestamp.py"))
+    let child = std::process::Command::new(ytdlp_get_script_path("ytdlp_signature_timestamp.py"))
         .arg(player_js_url)
         .arg(TEST_YOUTUBE_VIDEO)
         .output()
@@ -37,7 +37,7 @@ pub fn ytdlp_nsig_decoder(signature: &str, player_id: u32) -> String {
         "https://www.youtube.com/s/player/{:08x}/player_ias.vflset/en_US/base.js",
         player_id
     );
-    let mut child = std::process::Command::new(ytdlp_get_script_path("ytdlp_nsig_decoder.py"))
+    let child = std::process::Command::new(ytdlp_get_script_path("ytdlp_nsig_decoder.py"))
         .arg(player_js_url)
         .arg(signature)
         .arg(TEST_YOUTUBE_VIDEO)
@@ -53,7 +53,7 @@ pub fn ytdlp_sig_decoder(signature: &str, player_id: u32) -> String {
         "https://www.youtube.com/s/player/{:08x}/player_ias.vflset/en_US/base.js",
         player_id
     );
-    let mut child = std::process::Command::new(ytdlp_get_script_path("ytdlp_sig_decoder.py"))
+    let child = std::process::Command::new(ytdlp_get_script_path("ytdlp_sig_decoder.py"))
         .arg(player_js_url)
         .arg(signature)
         .arg(TEST_YOUTUBE_VIDEO)

--- a/src/ytdlp.rs
+++ b/src/ytdlp.rs
@@ -1,0 +1,60 @@
+mod consts;
+
+use ::futures::StreamExt;
+
+use consts::{ENV_USE_YT_DLP, "TEST_YOUTUBE_VIDEO"};
+
+fn ytdlp_requested() -> bool {
+    match std::env::var(ENV_USE_YT_DLP) {
+        Ok(val) => val == "1",
+        Err(_) => false,
+    }
+}
+
+fn ytdlp_signature_timestamp(player_id: u32) -> u64 {
+    let player_js_url: String = format!(
+        "https://www.youtube.com/s/player/{:08x}/player_ias.vflset/en_US/base.js",
+        player_id
+    );
+    let mut child = std::process::Command::new("src/ytdlp_signature_timestamp.py")
+        .arg(player_js_url)
+        .arg(TEST_YOUTUBE_VIDEO)
+        .output()
+        .expect("Failed to execute command");
+
+    let output = String::from_utf8_lossy(&child.stdout);
+    output.to_string().parse::<u64>().unwrap()
+}
+
+fn ytdlp_nsig_decoder(signature: &str, player_id: u32) -> String {
+    let player_js_url: String = format!(
+        "https://www.youtube.com/s/player/{:08x}/player_ias.vflset/en_US/base.js",
+        player_id
+    );
+    let mut child = std::process::Command::new("src/ytdlp_nsig_decoder.py")
+        .arg(player_js_url)
+        .arg(signature)
+        .arg(TEST_YOUTUBE_VIDEO)
+        .output()
+        .expect("Failed to execute command");
+
+    let output = String::from_utf8_lossy(&child.stdout);
+    output.to_string()
+}
+
+fn ytdlp_sig_decoder(signature: &str, player_id: u32) -> String {
+    let player_js_url: String = format!(
+        "https://www.youtube.com/s/player/{:08x}/player_ias.vflset/en_US/base.js",
+        player_id
+    );
+    let mut child = std::process::Command::new("src/ytdlp_sig_decoder.py")
+        .arg(player_js_url)
+        .arg(signature)
+        .arg(TEST_YOUTUBE_VIDEO)
+        .output()
+        .expect("Failed to execute command");
+
+    let output = String::from_utf8_lossy(&child.stdout);
+    output.to_string()
+}
+

--- a/src/ytdlp.rs
+++ b/src/ytdlp.rs
@@ -17,7 +17,7 @@ pub fn ytdlp_requested() -> bool {
     }
 }
 
-#[cached(size = 100)]
+#[cached(size = 10, time = 30)]
 pub fn ytdlp_signature_timestamp(player_id: u32) -> u64 {
     let player_js_url: String = format!(
         "https://www.youtube.com/s/player/{:08x}/player_ias.vflset/en_US/base.js",
@@ -33,7 +33,7 @@ pub fn ytdlp_signature_timestamp(player_id: u32) -> u64 {
     output.to_string().parse::<u64>().unwrap()
 }
 
-#[cached(size = 10000)]
+#[cached(size = 1000, time = 30)]
 pub fn ytdlp_nsig_decoder(signature: String, player_id: u32) -> String {
     let player_js_url: String = format!(
         "https://www.youtube.com/s/player/{:08x}/player_ias.vflset/en_US/base.js",
@@ -50,7 +50,7 @@ pub fn ytdlp_nsig_decoder(signature: String, player_id: u32) -> String {
     output.to_string()
 }
 
-#[cached(size = 10000)]
+#[cached(size = 1000, time = 30)]
 pub fn ytdlp_sig_decoder(signature: String, player_id: u32) -> String {
     let player_js_url: String = format!(
         "https://www.youtube.com/s/player/{:08x}/player_ias.vflset/en_US/base.js",

--- a/src/ytdlp.rs
+++ b/src/ytdlp.rs
@@ -1,11 +1,8 @@
-mod consts;
-
-use ::futures::StreamExt;
-use std::env;
+use std::env::var;
 use std::path::PathBuf;
-use std::process::Command;
+use std::process::Command::new;
 
-use consts::{ENV_USE_YT_DLP, TEST_YOUTUBE_VIDEO};
+use crate::consts::{ENV_USE_YT_DLP, TEST_YOUTUBE_VIDEO};
 
 fn ytdlp_get_script_path(script_name: &str) -> PathBuf {
     let exe_path = std::env::current_exe().expect("Failed to get current path of binary");


### PR DESCRIPTION
Thanks to these changes, signature decoding can be enabled using yt-dlp instead of the built-in code by setting the "USE_YT_DLP" environment variable.

This should help in cases where the built-in decoding logic stops working due to changes on YouTube's side.

This is my first-ever Rust implementation, so I apologize for any potential mistakes. However, everything appears to be functioning correctly.