### PR TITLE
Hotfix for new update signature func (eg player: #22f02d3d and #6450230e)

### DIFF
--- a/src/consts.rs
+++ b/src/consts.rs
@@ -22,9 +22,13 @@ pub static NSIG_FUNCTION_ENDINGS: &[&str] = &[
 
 pub static REGEX_SIGNATURE_TIMESTAMP: &Lazy<Regex> = regex!("signatureTimestamp[=:](\\d+)");
 
-pub static REGEX_SIGNATURE_FUNCTION: &Lazy<Regex> =
-    regex!(r#"\s*?([a-zA-Z0-9_\$]{1,})=function\([a-zA-Z]{1}\)\{(.{1}=.{1}\.split\([a-zA-Z0-9\-_\$\[\]"]+\)[^\}{]+)return .{1}\.join\([a-zA-Z0-9\-_\$\[\]"]+\)\}"#);
-pub static REGEX_HELPER_OBJ_NAME: &Lazy<Regex> = regex!(";([A-Za-z0-9_\\$]{2,})\\...\\(");
+pub static REGEX_SIGNATURE_FUNCTION_PATTERNS: &[&str] = &[
+    r#"\s*?([a-zA-Z0-9_\$]{1,})=function\([a-zA-Z]{1}\)\{(.{1}=.{1}\.split\([a-zA-Z0-9\-_\$\[\]"]+\)[^\}{]+)return .{1}\.join\([a-zA-Z0-9\-_\$\[\]"]+\)\}"#,
+    r#"([a-zA-Z0-9_$]{1,})=function\(r\)\{r=r\[[A-Z]\[\d+\]\]\([A-Z]\[\d+\]\);[a-zA-Z0-9$]+\[[A-Z]\[\d+\]\]\(r,\d+\);[a-zA-Z0-9$]+\[[A-Z]\[\d+\]\]\(r,\d+\);[a-zA-Z0-9$]+\[[A-Z]\[\d+\]\]\(r,\d+\);return r\[[A-Z]\[\d+\]\]\([A-Z]\[\d+\]\)\}"#,
+];
+
+// pub static REGEX_SIGNATURE_FUNCTION: &Lazy<Regex> = regex!(r#"\s*?([a-zA-Z0-9_\$]{1,})=function\([a-zA-Z]{1}\)\{(.{1}=.{1}\.split\([a-zA-Z0-9\-_\$\[\]"]+\)[^\}{]+)return .{1}\.join\([a-zA-Z0-9\-_\$\[\]"]+\)\}"#);
+pub static REGEX_HELPER_OBJ_NAME: &Lazy<Regex> = regex!(";([A-Za-z0-9_\\$]{2,})(?:\\.|\\[)");
 
 pub static NSIG_FUNCTION_NAME: &str = "decrypt_nsig";
 pub static SIG_FUNCTION_NAME: &str = "decrypt_sig";

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -23,8 +23,9 @@ pub static NSIG_FUNCTION_ENDINGS: &[&str] = &[
 pub static REGEX_SIGNATURE_TIMESTAMP: &Lazy<Regex> = regex!("signatureTimestamp[=:](\\d+)");
 
 pub static REGEX_SIGNATURE_FUNCTION_PATTERNS: &[&str] = &[
-    r#"\s*?([a-zA-Z0-9_\$]{1,})=function\([a-zA-Z]{1}\)\{(.{1}=.{1}\.split\([a-zA-Z0-9\-_\$\[\]"]+\)[^\}{]+)return .{1}\.join\([a-zA-Z0-9\-_\$\[\]"]+\)\}"#,
-    r#"([a-zA-Z0-9_$]{1,})=function\(r\)\{r=r\[[A-Z]\[\d+\]\]\([A-Z]\[\d+\]\);[a-zA-Z0-9$]+\[[A-Z]\[\d+\]\]\(r,\d+\);[a-zA-Z0-9$]+\[[A-Z]\[\d+\]\]\(r,\d+\);[a-zA-Z0-9$]+\[[A-Z]\[\d+\]\]\(r,\d+\);return r\[[A-Z]\[\d+\]\]\([A-Z]\[\d+\]\)\}"#,
+    r#"\s*?([a-zA-Z0-9_\$]{1,})=function\([a-zA-Z]{1}\)\{(.{1}=.{1}\.split\([a-zA-Z0-9\-_\$\[\]"]+\)[^\}{]+)return .{1}\.join\([a-zA-Z0-9\-_\$\[\]"]+\)\}"#, // old regex
+    r#"([a-zA-Z0-9_$]{1,})=function\(([a-zA-Z0-9_$]{1})\)\{[^}]*GLOBAL_VAR_NAME\[[^\]]+\][^}]*return [^}]*GLOBAL_VAR_NAME\[[^\]]+\][^}]*\}"#, // new regex
+    r#"([a-zA-Z0-9_$]{1,})=function\(([a-zA-Z0-9_$]{1})\)\{[^}]*return [^}]*GLOBAL_VAR_NAME\[[^\]]+\][^}]*\}"#, // more general regex
 ];
 
 // pub static REGEX_SIGNATURE_FUNCTION: &Lazy<Regex> = regex!(r#"\s*?([a-zA-Z0-9_\$]{1,})=function\([a-zA-Z]{1}\)\{(.{1}=.{1}\.split\([a-zA-Z0-9\-_\$\[\]"]+\)[^\}{]+)return .{1}\.join\([a-zA-Z0-9\-_\$\[\]"]+\)\}"#);

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -14,6 +14,7 @@ pub static NSIG_FUNCTION_ARRAYS: &[&str] = &[
 ];
 
 pub static NSIG_FUNCTION_ENDINGS: &[&str] = &[
+    r#"=\s*function([\S\s]*?\}\s*return [A-Za-z0-9$]+\[[A-Za-z0-9$]+\[\d+\]\]\([A-Za-z0-9$]+\[\d+\]\)\s*\};)"#,
     r#"=\s*function(\(\w\)\s*\{[\S\s]*\{return.[a-zA-Z0-9_-]+_w8_.+?\}\s*return\s*\w+.join\(""\)\};)"#,
     r#"=\s*function([\S\s]*?\}\s*return \w+?\.join\([^)]+\)\s*\};)"#,
     r#"=\s*function([\S\s]*?\}\s*return [\W\w$]+?\.call\([\w$]+?,\"\"\)\s*\};)"#,

--- a/src/player.rs
+++ b/src/player.rs
@@ -275,9 +275,8 @@ pub async fn fetch_update(state: Arc<GlobalState>) -> Result<(), FetchUpdateStat
         sig_code += helper_object_body;
         sig_code += sig_function_body;
     } else {
-        // just return empty sig function code
-        // random sig_function_name
-        let sig_function_name = format!("sig_function_{}", SystemTime::now().elapsed().unwrap().as_millis());
+        // just return empty sig function code with random name
+        let sig_function_name = format!("sig_function_{}", SystemTime::now().duration_since(SystemTime::UNIX_EPOCH).unwrap().as_millis());
         sig_code += "var ";
         sig_code += &sig_function_name;
         sig_code += ";";


### PR DESCRIPTION
1. Updated NSIG_FUNCTION_ENDINGS, REGEX_SIGNATURE_FUNCTION_PATTERNS (keep old, and add new regex that use global var name from player.rs), and REGEX_HELPER_OBJ_NAME to match new patterns.
2. Fixed crash in inv_sig_helper when no signature function is found, allow NSIG code decryption even when signature code is missing.