### PR TITLE
Added signal handling for graceful shutdown

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,7 +5,6 @@ services:
       context: .
       dockerfile: Dockerfile
     # image: quay.io/invidious/inv-sig-helper:latest
-    init: true
     command: ["--tcp", "127.0.0.1:12999"]
     ports:
       - 127.0.0.1:12999:12999


### PR DESCRIPTION
Replaced blocking accept() loop with tokio::select! to handle SIGTERM and SIGINT signals. This allows the process to exit cleanly instead of being forcibly killed.

Unlike the Docker workaround in 215d32c (#20), this solution fixes the issue at the application level and works in all environments (Docker, Kubernetes, bare metal) without relying on external process managers.